### PR TITLE
Add test to verify data integrity in CI

### DIFF
--- a/.claude/things-both-ingredient-and-not.md
+++ b/.claude/things-both-ingredient-and-not.md
@@ -1,0 +1,65 @@
+# Problem: items that are both supply and ingredient
+
+## Current model
+
+`supplies.json` has boolean `isIngredient`. Mutually exclusive:
+- `isIngredient: false` → appears in CruiseSuppliesTab (additional supplies / shopping list)
+- `isIngredient: true` → appears as recipe ingredient, hidden from supplies tab by default
+
+`CruiseSuppliesTab` toggle: checkbox OFF = non-ingredients, checkbox ON = ingredients.
+`getSuppliesByType(showIngredients)` → either `getNonIngredients()` or `getIngredients()`.
+
+## Known dual-purpose case
+
+`woda_butelkowana`:
+- currently `isIngredient: false`, `unit: sztuki`
+- used as recipe ingredient in `owsianka` (125) and `nalesniki-z-dzemem` (125)
+- also needs to appear in supplies tab for drinking water logistics (per-person/per-day)
+- unit should be volume (`litry` or `ml`), not `sztuki`
+
+## Only current overlap (verified)
+
+Only `woda_butelkowana` is a non-ingredient supply referenced by recipes.
+But potential future candidates exist in non-ingredient categories:
+- `napoje`: herbata, kawa, sok_owocowy, woda_butelkowana_gazowana — plausible recipe use
+- `przekąski`: budyn, kisiel, zupki_w_proszku — plausible recipe use
+- `przyprawy`: syrop_malinowy — plausible recipe use
+
+## Options
+
+### Option A — two independent boolean flags
+Add `isAdditionalSupply: boolean` alongside `isIngredient: boolean`.
+
+- `getNonIngredients()` → `getAdditionalSupplies()` (where `isAdditionalSupply: true`)
+- `getIngredients()` unchanged (where `isIngredient: true`)
+- Water gets both flags `true` → appears in both views
+- All current non-ingredients need `isAdditionalSupply: true` added (43 entries)
+- All current ingredients keep `isAdditionalSupply: false` (default/omitted)
+
+**Pro:** clean semantics, independent axes, extensible to other dual-purpose items.
+**Con:** 43-entry data migration, naming `isAdditionalSupply` may be confusing.
+
+### Option B — enum/multi-value type
+Replace `isIngredient: boolean` with `type: "ingredient" | "supply" | "both"`.
+
+- Filter functions rewritten to check type
+- Water gets `type: "both"`
+
+**Pro:** single field, explicit.
+**Con:** breaking change to all consumers, more complex filter logic.
+
+### Option C — keep boolean, show ingredients in supplies tab too (checkbox becomes additive)
+Change checkbox from "show ingredients instead" to "also show ingredients".
+
+- `getSuppliesByType(showIngredients)` returns non-ingredients always + ingredients if checked
+- Water flips to `isIngredient: true`, removed from non-ingredient list
+- Appears in supplies tab only when checkbox ON
+
+**Pro:** minimal data change (just fix water unit + flag).
+**Con:** changes UX meaning of checkbox, ingredients flood supplies tab when checked.
+
+## Open questions
+
+1. Is `isAdditionalSupply` the right name, or better `isSupply` / `showInSuppliesTab`?
+2. Should future `napoje`/`przekąski`/`przyprawy` items be dual-purpose proactively, or case-by-case?
+3. Unit for water: `litry` (consistent with other liquid ingredients) or `ml`?

--- a/src/data/recipies.json
+++ b/src/data/recipies.json
@@ -425,7 +425,7 @@
         "amount": 125
       },
       {
-        "id": "woda_butelkowana",
+        "id": "woda",
         "amount": 125
       },
       {
@@ -544,7 +544,7 @@
         "amount": 125
       },
       {
-        "id": "woda_butelkowana",
+        "id": "woda",
         "amount": 125
       },
       {

--- a/src/data/supplies.json
+++ b/src/data/supplies.json
@@ -392,6 +392,16 @@
     "isIngredient": false
   },
   {
+    "id": "woda",
+    "name": "Woda pitna",
+    "description": "",
+    "unit": "ml",
+    "category": "napoje",
+    "isIngredient": true,
+    "isVegetarian": true,
+    "isVegan": true
+  },
+  {
     "id": "woda_butelkowana",
     "name": "Woda butelkowana niegazowana",
     "description": "1,5L/osobę/dzień",

--- a/src/data/supplies.json
+++ b/src/data/supplies.json
@@ -275,7 +275,7 @@
     "isIngredient": true
   },
   {
-    "id": "wędlina_prozniowo",
+    "id": "wedlina_prozniowo",
     "name": "Wędlina pakowana próżniowo",
     "unit": "gramy",
     "category": "mięso",
@@ -500,6 +500,15 @@
     "unit": "saszetki",
     "category": "przekąski",
     "isIngredient": false
+  },
+  {
+    "id": "orzechy_wloskie",
+    "name": "Orzechy włoskie",
+    "unit": "gramy",
+    "category": "przekąski",
+    "isVegetarian": true,
+    "isVegan": true,
+    "isIngredient": true
   },
   {
     "id": "orzeszki_solone",

--- a/test/dataIntegrityTests.test.ts
+++ b/test/dataIntegrityTests.test.ts
@@ -1,0 +1,46 @@
+import recipies from '../src/data/recipies.json';
+import supplies from '../src/data/supplies.json';
+
+describe('data integrity', () => {
+  describe('duplicate IDs', () => {
+    it('supplies.json has no duplicate IDs', () => {
+      const seen = new Set<string>();
+      const duplicates: string[] = [];
+      for (const supply of supplies) {
+        if (seen.has(supply.id)) duplicates.push(supply.id);
+        else seen.add(supply.id);
+      }
+      expect(duplicates.join(', ')).toBe('');
+    });
+
+    it('recipies.json has no duplicate IDs', () => {
+      const seen = new Set<string>();
+      const duplicates: string[] = [];
+      for (const recipie of recipies) {
+        if (seen.has(recipie.id)) duplicates.push(recipie.id);
+        else seen.add(recipie.id);
+      }
+      expect(duplicates.join(', ')).toBe('');
+    });
+  });
+
+  describe('ingredient references', () => {
+    it('all recipe ingredients refer to existing supplies with isIngredient: true', () => {
+      const supplyMap = new Map(supplies.map(s => [s.id, s]));
+      const violations: string[] = [];
+
+      for (const recipie of recipies) {
+        for (const ingredient of recipie.ingredients) {
+          const supply = supplyMap.get(ingredient.id);
+          if (!supply) {
+            violations.push(`${recipie.id}: ${ingredient.id} (not found in supplies.json)`);
+          } else if (!supply.isIngredient) {
+            violations.push(`${recipie.id}: ${ingredient.id} (isIngredient is false)`);
+          }
+        }
+      }
+
+      expect(violations.join('\n')).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
Cóż, trochę jest późno a woda_butelkowana jest moją zmorą.

W sumie to podoba mi się ta opcja z enumem, ale to będzie sporo zmian. Ale w tym formacie to woda jednocześnie jest additional supply i ingredient. A przepisy jej używają mimo, że isIngredient ma na false. Pytanie jaki miałeś zamiar z tą flagą? Bo niby jest checkbox na tym tabie z additional supplies, że "pokaż składniki"